### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
    ```shell
    wget https://cdn.jsdelivr.net/gh/justjavac/certbot-dns-aliyun/alidns.sh
    sudo cp alidns.sh /usr/local/bin
+   sudo chmod +x /usr/local/bin/alidns.sh
    sudo ln -s /usr/local/bin/alidns.sh /usr/local/bin/alidns
    ```
 


### PR DESCRIPTION
给 alidns.sh 添加可执行权限，否则可能会报 `Unable to find manual-auth-hook command alidns in the PATH`